### PR TITLE
Fix tests halting

### DIFF
--- a/OpenAPIMock/app.js
+++ b/OpenAPIMock/app.js
@@ -6,7 +6,6 @@ var middleware = require('swagger-express-middleware');
 var path = require('path');
 const bodyParser = require('body-parser');
 var mock_controller = require("./api/mocks/mock_controller");
-
 //pass the express app to the mock controller
 var app = mock_controller.init();
 app.use(bodyParser.json());
@@ -32,7 +31,12 @@ middleware(path.join(__dirname, 'api/swagger/swagger.yaml'), app, function (err,
   // creates user defined responses for certain error codes
   mock_controller.customErrorResponses(app);
 
-  app.listen(10000, function () {
-    console.log('OpenAPI Mock is now running at http://localhost:10000');
-  });
+
+
 });
+
+var server = app.listen(10000, function () {
+  console.log('OpenAPI Mock is now running at http://localhost:10000');
+
+});
+module.exports = server

--- a/OpenAPIMock/test/test_openapi.js
+++ b/OpenAPIMock/test/test_openapi.js
@@ -1,7 +1,5 @@
-var should = require('should');
 var request = require('supertest');
 var server = require('../app');
-
 describe('controllers', function () {
 
   describe('test_openapi', function () {
@@ -10,7 +8,7 @@ describe('controllers', function () {
 
       it('should return response 200', function (done) {
 
-        request("http://localhost:10000")
+        request(server)
           .get('/metadata')
           .set('Accept', 'application/json')
           .expect('Content-Type', 'text/x-yaml; charset=utf-8')
@@ -21,5 +19,6 @@ describe('controllers', function () {
     });
 
   });
+  after(() => { server.close() })
 
 });


### PR DESCRIPTION
Once server is started by the required code, it never closes so tests
never exit. To fix that I exported server from app.js and call server.close()
at the end of test file. To export the server, I moved app.listen(), outside of
callback, which probably broke functionality.