### PR TITLE
pin all base images to v11

### DIFF
--- a/app-connector-client/Dockerfile
+++ b/app-connector-client/Dockerfile
@@ -1,6 +1,7 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
-WORKDIR /app 
+WORKDIR /app
 COPY package*.json ./
 
 RUN npm install

--- a/app-connector-client/Dockerfile
+++ b/app-connector-client/Dockerfile
@@ -4,6 +4,7 @@ RUN apk --no-cache upgrade
 WORKDIR /app
 COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
 COPY . .
 

--- a/examples/combined-odata-mock/Dockerfile
+++ b/examples/combined-odata-mock/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:11-alpine
 RUN apk --no-cache upgrade
 
-COPY . /app
 WORKDIR /app
+COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
+COPY . .
 
 EXPOSE 10000
 CMD ["npm","start"]

--- a/examples/combined-odata-mock/Dockerfile
+++ b/examples/combined-odata-mock/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
 COPY . /app
 WORKDIR /app

--- a/examples/combined-openapi-mock/Dockerfile
+++ b/examples/combined-openapi-mock/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:11-alpine
 RUN apk --no-cache upgrade
 
-COPY . /app
 WORKDIR /app
+COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
+COPY . .
 
 EXPOSE 10000
 CMD ["npm","start"]

--- a/examples/combined-openapi-mock/Dockerfile
+++ b/examples/combined-openapi-mock/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
 COPY . /app
 WORKDIR /app

--- a/examples/odata-mock/Dockerfile
+++ b/examples/odata-mock/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:11-alpine
 RUN apk --no-cache upgrade
 
-COPY . /app
 WORKDIR /app
+COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
+COPY . .
 
 EXPOSE 10000
 CMD ["npm","start"]

--- a/examples/odata-mock/Dockerfile
+++ b/examples/odata-mock/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
 COPY . /app
 WORKDIR /app

--- a/examples/openapi-mock/Dockerfile
+++ b/examples/openapi-mock/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:11-alpine
 RUN apk --no-cache upgrade
 
-COPY . /app
 WORKDIR /app
+COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
+COPY . .
 
 EXPOSE 10000
 CMD ["npm","start"]

--- a/examples/openapi-mock/Dockerfile
+++ b/examples/openapi-mock/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
 COPY . /app
 WORKDIR /app

--- a/odata-mock/Dockerfile
+++ b/odata-mock/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:11-alpine
 RUN apk --no-cache upgrade
 
-COPY . /odata-mock
-WORKDIR /odata-mock
+WORKDIR /app
+COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
+COPY . .
 
 EXPOSE 10000
 CMD ["npm","start"]

--- a/odata-mock/Dockerfile
+++ b/odata-mock/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
 COPY . /odata-mock
 WORKDIR /odata-mock

--- a/openapi-mock/Dockerfile
+++ b/openapi-mock/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:11-alpine
+RUN apk --no-cache upgrade
 
 COPY . /app
 WORKDIR /app

--- a/openapi-mock/Dockerfile
+++ b/openapi-mock/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:11-alpine
 RUN apk --no-cache upgrade
 
-COPY . /app
 WORKDIR /app
+COPY package*.json ./
 
+ENV NODE_ENV=production
 RUN npm install
+COPY . .
 
 EXPOSE 10000
-CMD ["node","start"]
+CMD ["npm","start"]


### PR DESCRIPTION
closes #93 

All docker images in the project are pinned to version 11 of node alpine image. 

The node image dockerhub page is: https://hub.docker.com/_/node/?tab=description