### PR TITLE
docker-build only for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 APP_NAME = varkes
+varkes_version :=$(shell cat lerna.json | jq .version) #read project version.
 
+ifeq ($(varkes_version), "0.0.0" )
+        DOCKER_TAG=master # 0.0.0 means we are in master branch
+else
+        DOCKER_TAG=$(varkes_version) #else use defined version by lerna version
+endif
 .PHONY: ci-pr
 ci-pr: resolve validate
 
@@ -7,7 +13,7 @@ ci-pr: resolve validate
 ci-master: resolve validate
 
 .PHONY: ci-release
-ci-release: npm-publish
+ci-release: npm-publish docker-push
 
 resolve:
 	npx lerna bootstrap --hoist
@@ -21,3 +27,8 @@ npm-publish:
 clean:
 	lerna clean
 
+test:
+	echo $(DOCKER_TAG)
+docker-push:
+	#call docker-push in sub makefiles with docker parameter
+	lerna exec --no-bail -- make docker-push DOCKER_TAG=$(DOCKER_TAG)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Mocks REST calls given an OpenAPI specification. [openapi-mock/README.md](openap
 ## Odata Mock
 Mocks rest calls given an OData specification [odata-mock/README.md](odata-mock/README.md).
 
+## Examples
+Examples folder provides mocks written using openapi & odata packages. If you want to use them without cloning the whole repo, please refer to tags in `release` branch. There, you can find the latest version of the dependencies already included in their package.json files. Working on examples in master branch without cloning the whole repo is currently impossible because they use development version numbers in their package.jsons and these are not published to npm registry.
+
+To create docker images of examples, please also refer to `release` branch, where npm installed in docker containers can get the latest version from the registry.
+
 ## Developing
 This project is maintained by Lerna. To start developing, clone this repo and run `lerna bootstrap --hoist` to install dependencies and link local dependencies.
 
@@ -21,5 +26,3 @@ After that step, you can make your changes and commit freely. There is no need t
 To increase version number, run `lerna version --no-git-tag-version`. It asks user the new version number. When omitting the flag, it also creates a new git tag with the given version number. This command also updates the dependency version in the `package.json` of subprojects.
 
 To see how CI operates on Lerna, check the makefile in the root folder.
-
-`lerna publish` automatically increases version number before publishing so we are using `npm publish` instead and just use lerna to run that command in projects. To test publishing scheme, you can use [verdaccio](https://github.com/verdaccio/verdaccio) for setting up a private registry.

--- a/app-connector-client/Makefile
+++ b/app-connector-client/Makefile
@@ -1,13 +1,5 @@
 APP_NAME = varkes-app-connector-client
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
-TAG = $(DOCKER_TAG)
-
-.PHONY: ci-pr
-ci-pr: resolve docker-build docker-push
-
-.PHONY: ci-master
-ci-master: resolve docker-build docker-push npm-publish
-
 resolve:
 	npm install
 
@@ -18,12 +10,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
-
-npm-publish:
-	npm version "patch" --git-tag-version=false
-	npm publish
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./logs

--- a/examples/combined-odata-mock/Makefile
+++ b/examples/combined-odata-mock/Makefile
@@ -2,12 +2,6 @@ APP_NAME = varkes-example-combined-odata-mock
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
-.PHONY: ci-pr
-ci-pr: resolve validate docker-build
-
-.PHONY: ci-master
-ci-master: resolve validate docker-build docker-push
-
 resolve:
 	npm install
 
@@ -18,8 +12,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./requests.log ./n_odata_server.log

--- a/examples/combined-openapi-mock/Makefile
+++ b/examples/combined-openapi-mock/Makefile
@@ -3,12 +3,6 @@ APP_NAME = varkes-example-combined-openapi-mock
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
-.PHONY: ci-pr
-ci-pr: resolve validate docker-build
-
-.PHONY: ci-master
-ci-master: resolve validate docker-build docker-push
-
 resolve:
 	npm install
 
@@ -19,8 +13,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./requests.log ./generated

--- a/examples/kyma-mock/Makefile
+++ b/examples/kyma-mock/Makefile
@@ -3,12 +3,6 @@ APP_NAME = varkes-example-kyma-mock
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
-.PHONY: ci-pr
-ci-pr: resolve validate docker-build
-
-.PHONY: ci-master
-ci-master: resolve validate docker-build docker-push
-
 resolve:
 	npm install
 
@@ -19,8 +13,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./requests.log ./generated

--- a/examples/openapi-mock/Makefile
+++ b/examples/openapi-mock/Makefile
@@ -3,12 +3,6 @@ APP_NAME = varkes-example-openapi-mock
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
-.PHONY: ci-pr
-ci-pr: resolve validate docker-build
-
-.PHONY: ci-master
-ci-master: resolve validate docker-build docker-push
-
 resolve:
 	npm install
 
@@ -19,8 +13,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./requests.log ./generated

--- a/odata-mock/Makefile
+++ b/odata-mock/Makefile
@@ -3,12 +3,6 @@ APP_NAME = varkes-odata-mock
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
-.PHONY: ci-pr
-ci-pr: resolve validate docker-build docker-push
-
-.PHONY: ci-master
-ci-master: resolve validate docker-build docker-push npm-publish
-
 resolve:
 	npm install
 
@@ -19,12 +13,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
-
-npm-publish:
-	npm version "patch" --git-tag-version=false
-	npm publish
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./requests.log ./n_odata_server.log

--- a/openapi-mock/Makefile
+++ b/openapi-mock/Makefile
@@ -3,12 +3,6 @@ APP_NAME = varkes-openapi-mock
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME)
 TAG = $(DOCKER_TAG)
 
-.PHONY: ci-pr
-ci-pr: resolve validate docker-build docker-push
-
-.PHONY: ci-master
-ci-master: resolve validate docker-build docker-push npm-publish
-
 resolve:
 	npm install
 
@@ -19,12 +13,11 @@ docker-build:
 	docker build -t $(APP_NAME):latest .
 
 docker-push:
-	docker tag $(APP_NAME) $(IMG):latest
-	docker push $(IMG):latest
-
-npm-publish:
-	npm version "patch" --git-tag-version=false
-	npm publish
+	make docker-build
+	#DOCKER_TAG comes as parameter from outside -> make docker-push DOCKER_TAG=master
+	echo $(DOCKERT_TAG)
+	docker tag $(APP_NAME) $(IMG):$(DOCKER_TAG)
+	docker push $(IMG):$(DOCKER_TAG)
 
 clean:
 	rm -rf ./node_modules ./requests.log ./generated

--- a/package.json
+++ b/package.json
@@ -3,9 +3,5 @@
   "private": true,
   "devDependencies": {
     "lerna": "^3.13.0"
-  },
-  "scripts": {
-    "test": "lerna exec --concurrency 1 -- npm test",
-    "publish": "lerna exec --no-bail -- npm publish"
   }
 }


### PR DESCRIPTION
This pr includes docker artifacts to release pipeline. Currently only post-release job will produce and push docker images. The reason for this is explained in the Readme. To summary the problem again:

- In master, example projects have local dependencies that have the version 0.0.0. When copied to docker, this local dependency becomes unavailable. 
- In release job, the versions are updated and we first push the packages to npm, so those pushed packages can be used by the docker image while building. 