### PR TITLE
Add compile step to development instruction

### DIFF
--- a/app-connector-client/README.md
+++ b/app-connector-client/README.md
@@ -15,19 +15,17 @@ After the startup, you have access to:
 
 ## Development
 
+Make sure you have first executed `make resolve` from the project root!
+
 To run the Client locally with an empty configuration, use:
 ```
 npm start
-
 ```
 To run it locally with debug logs enabled and an example configuration from the test suite, use:
 
 ```
 npm run start:dev
-
 ```
 
 ## Documentation
 You can access OpenAPI documentation using `localhost:10000/metadata` or the [api.yaml](server/resources/api.yaml) file.
-
-

--- a/odata-mock/README.md
+++ b/odata-mock/README.md
@@ -20,16 +20,16 @@ The OData mock brings you the following features:
 
 ## Development
 
+Make sure you have first executed `make resolve` from the project root!
+
 To run the Odata mock locally with an empty configuration, use:
 ```
 npm start
-
 ```
 To run it locally with debug logs enabled and an example configuration from the test suite, use:
 
 ```
 npm run start:dev
-
 ```
 After the startup, you have access to:
 - odata API - `http://localhost:10000/odata/`

--- a/openapi-mock/README.md
+++ b/openapi-mock/README.md
@@ -21,16 +21,16 @@ The OpenAPI mock brings you the following features:
 
 ## Development
 
+Make sure you have first executed `make resolve` from the project root!
+
 To run the OpenAPI mock locally, use an empty configuration:
 ```
 npm start
-
 ```
 To run it locally with debug logs enabled, and an example configuration from the test suite, run:
 
 ```
 npm run start:dev
-
 ```
 
 After the startup, you have access to:


### PR DESCRIPTION
In a fresh installation it is not possible to execute `npm start`. The command fails because the dist directory does not exist yet. Executing `npm install` and `npm run compile` fixed it for me.