### PR TITLE
enabled boot scripts and discarded useless scripts

### DIFF
--- a/odata-mock/src/server/app.ts
+++ b/odata-mock/src/server/app.ts
@@ -56,7 +56,7 @@ async function generateBootConfig(api: any) {
   var parsedModel = await parser.parseEdmx(api.specification, dataSourceName)
 
   //for configuration, see https://apidocs.strongloop.com/loopback-boot/
-  var bootConfig = JSON.parse(fs.readFileSync(__dirname + "/resources/boot_config_template.json", "utf-8"))
+  var bootConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, "resources/boot_config_template.json"), "utf-8"))
 
   parsedModel.modelConfigs.forEach(function (config: any) {
     bootConfig.models[config.name] = config.value
@@ -99,6 +99,7 @@ async function generateBootConfig(api: any) {
     bootConfig.dataSources[dataSourceName].file = "data/" + dataSourceName + ".json"
   }
 
+  bootConfig.bootScripts = [path.resolve(__dirname, "routes.js")]
   return bootConfig
 }
 

--- a/odata-mock/src/server/boot/authentication.ts
+++ b/odata-mock/src/server/boot/authentication.ts
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-'use strict'
-
-module.exports = function enableAuthentication(server: any) {
-  server.enableAuth();
-}

--- a/odata-mock/src/server/boot/root.ts
+++ b/odata-mock/src/server/boot/root.ts
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-'use strict'
-
-module.exports = function (server: any) {
-  var router = server.loopback.Router();
-  router.get('/', server.loopback.status());
-  server.use(router);
-}

--- a/odata-mock/src/server/routes.ts
+++ b/odata-mock/src/server/routes.ts
@@ -3,7 +3,7 @@
 
 const bodyParser = require('body-parser');
 const morgan = require('morgan')
-import { logger as LOGGER } from "../logger"
+import { logger as LOGGER } from "./logger"
 const fs = require('fs');
 
 module.exports = function (app: any) {


### PR DESCRIPTION
There are three different routes for the odata loopback configuration which were not picked up.
I found a way to fix that and deleted two of them as they were useless.