### PR TITLE
removed istio annotations as they are not required anymore

### DIFF
--- a/app-connector-client/deployment/deployment.yaml
+++ b/app-connector-client/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: app-connector-client
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/develop/varkes-app-connector-client:latest

--- a/examples/combined-odata-mock/deployment/deployment.yaml
+++ b/examples/combined-odata-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: example-combined-odata-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/varkes-example-combined-odata-mock:latest

--- a/examples/combined-openapi-mock/deployment/deployment.yaml
+++ b/examples/combined-openapi-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: example-combined-openapi-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/varkes-example-combined-openapi-mock:latest

--- a/examples/kyma-mock/deployment/deployment.yaml
+++ b/examples/kyma-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: example-kyma-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/varkes-example-kyma-mock:latest

--- a/examples/odata-mock/deployment/deployment.yaml
+++ b/examples/odata-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: example-odata-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/varkes-example-odata-mock:latest

--- a/examples/openapi-mock/deployment/deployment.yaml
+++ b/examples/openapi-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: example-openapi-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/varkes-example-openapi-mock:latest

--- a/examples/stress-mock/deployment/deployment.yaml
+++ b/examples/stress-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: example-stress-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
         - image: eu.gcr.io/kyma-project/incubator/varkes-example-stress-mock:latest

--- a/odata-mock/deployment/deployment.yaml
+++ b/odata-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: odata-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/develop/varkes-odata-mock:latest

--- a/openapi-mock/deployment/deployment.yaml
+++ b/openapi-mock/deployment/deployment.yaml
@@ -10,8 +10,6 @@ spec:
     metadata:
       labels:
         app: openapi-mock
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - image: eu.gcr.io/kyma-project/incubator/develop/varkes-openapi-mock:latest


### PR DESCRIPTION
sidecar injection is enabled by default in kyma, so no need to enable it explicitly per deployment