### PR TITLE
Swagger ui

### DIFF
--- a/app-connector-client/package-lock.json
+++ b/app-connector-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/app-connector-client",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -920,11 +920,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"ejs": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -4664,7 +4659,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {

--- a/app-connector-client/package-lock.json
+++ b/app-connector-client/package-lock.json
@@ -5014,6 +5014,11 @@
 				}
 			}
 		},
+		"swagger-ui-dist": {
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.1.tgz",
+			"integrity": "sha512-KITbEqXkXrjGH12A0lpVZlH3uODFkwUh8d15My1YD4N0PSZDnIiC1iMFT6ryyuJxDYWZh0qezKpPqa5FRowngw=="
+		},
 		"swap-case": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",

--- a/app-connector-client/package.json
+++ b/app-connector-client/package.json
@@ -29,6 +29,7 @@
     "openapi-sampler": "^1.0.0-beta.14",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
+    "swagger-ui-dist": "^3.22.1",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/app-connector-client/server/app.js
+++ b/app-connector-client/server/app.js
@@ -21,6 +21,8 @@ const REMOTE_APIS_URL = "/remote/apis";
 const EVENTS_URL = "/events";
 const CONNECTION = "/connection";
 const BATCH_REGISTRATION = "/local/registration";
+
+const pathToSwaggerUI = require("swagger-ui-dist").absolutePath()
 function init(varkesConfigPath = null, currentPath = "", nodePortParam = null) {
 
     var varkesConfig = config(varkesConfigPath, currentPath)
@@ -36,6 +38,8 @@ function init(varkesConfigPath = null, currentPath = "", nodePortParam = null) {
     app.use(LOCAL_APIS_URL, localApis.router(varkesConfig))
     app.use(CONNECTION, connector.router(varkesConfig, nodePortParam))
     app.use(EVENTS_URL, events.router())
+
+    app.use("/swagger-ui", express.static(pathToSwaggerUI))
 
     app.get("/info", function (req, res) {
 

--- a/app-connector-client/server/resources/console.html
+++ b/app-connector-client/server/resources/console.html
@@ -3,26 +3,59 @@
 
 <head>
   <title>Varkes Application Connector Client</title>
+  <link rel="icon" href="favicon.ico?" type="image/x-icon">
   <!-- needed for adaptive design -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="favicon.ico?" type="image/x-icon">
   <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-
-  <!--
-    ReDoc doesn't change outer page styles
-    -->
+  <link href="/swagger-ui/swagger-ui.css" rel="stylesheet">
+  <!--refer to app.js to see how swagger-ui is served.-->
   <style>
+    html {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+
+    *,
+    *:before,
+    *:after {
+      box-sizing: inherit;
+    }
+
     body {
       margin: 0;
-      padding: 0;
+      background: #fafafa;
     }
   </style>
 </head>
 
 <body>
-  <redoc spec-url='/metadata'></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  <div id="swagger-ui"></div>
+
+  <script src="/swagger-ui/swagger-ui-bundle.js"> </script>
+  <script src="/swagger-ui/swagger-ui-standalone-preset.js"> </script>
+  <script>
+    window.onload = function () {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "/metadata",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+      // End Swagger UI call region
+
+      window.ui = ui
+    }
+  </script>
 </body>
 
 </html>

--- a/cockpit/package-lock.json
+++ b/cockpit/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/cockpit",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2178,6 +2178,7 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -3275,7 +3276,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -4072,7 +4074,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -4922,7 +4925,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5287,7 +5291,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5335,6 +5340,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5373,11 +5379,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
@@ -5386,6 +5394,7 @@
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -5413,6 +5422,7 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -5428,13 +5438,15 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5444,6 +5456,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5455,6 +5468,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5486,7 +5500,8 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
 			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"get-stream": {
 			"version": "4.1.0",
@@ -5695,7 +5710,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -6320,7 +6336,8 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -6657,6 +6674,7 @@
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
@@ -6669,7 +6687,8 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6860,7 +6879,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -7556,6 +7576,7 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -8486,6 +8507,7 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -8497,6 +8519,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -8507,7 +8530,8 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -8516,6 +8540,7 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"read-pkg": "^1.0.0"
@@ -8526,6 +8551,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -8536,6 +8562,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -8873,13 +8900,15 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -8905,6 +8934,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -8934,6 +8964,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -8945,6 +8976,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9811,6 +9843,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-utf8": "^0.2.0"
 			}
@@ -10796,6 +10829,7 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}

--- a/examples/combined-odata-mock/package-lock.json
+++ b/examples/combined-odata-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/example-combined-odata-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -210,15 +210,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
-		},
-		"cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"requires": {
-				"object-assign": "^4",
-				"vary": "^1"
-			}
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -861,11 +852,6 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-keys": {
 			"version": "1.1.1",

--- a/examples/combined-openapi-mock/package-lock.json
+++ b/examples/combined-openapi-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/example-combined-openapi-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/examples/kyma-mock/package-lock.json
+++ b/examples/kyma-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/example-kyma-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/examples/odata-mock/package-lock.json
+++ b/examples/odata-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/example-odata-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/examples/openapi-mock/package-lock.json
+++ b/examples/openapi-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/example-openapi-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/examples/stress-mock/package-lock.json
+++ b/examples/stress-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/stress-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/odata-mock/package-lock.json
+++ b/odata-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/odata-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -828,7 +828,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",

--- a/openapi-mock/package-lock.json
+++ b/openapi-mock/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@varkes/openapi-mock",
-	"version": "0.4.0",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -194,11 +194,11 @@
 			}
 		},
 		"api-spec-converter": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/api-spec-converter/-/api-spec-converter-2.8.1.tgz",
-			"integrity": "sha512-IUpvGfJ8nc6tPhHivyTZcNqpDWrwVl4L3BfyYxqIYSo+e+lK75Qni79uYQOQFKhPTR3VTOwoTaaXqoyUZ0Ibeg==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/api-spec-converter/-/api-spec-converter-2.8.3.tgz",
+			"integrity": "sha512-Eh2YiLHyP0e5UGCUIbWcL82V/ryCbk/ehQMo/IZRkYSsN0UMFA+PouV9GcsvcXn9uJRJgRBQCLVr7G+NBLhFtw==",
 			"requires": {
-				"apib2swagger": "^1.8.0",
+				"apib2swagger": "^1.9.0",
 				"bluebird": "^3.5.4",
 				"commander": "^2.20.0",
 				"composite-error": "^0.1.1",
@@ -225,9 +225,9 @@
 			"integrity": "sha1-YQg+4aZgwsMo90c/tkMYEqZabLU="
 		},
 		"apib2swagger": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/apib2swagger/-/apib2swagger-1.8.0.tgz",
-			"integrity": "sha512-xxU+O0mQcvrVfyoOCS0WCwlDyr/eyrK83cHHkiKs9vFPRL/U/PjyrZZpZG4n534x0iq0LvdBuLG1MkMWNJJYuw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/apib2swagger/-/apib2swagger-1.9.2.tgz",
+			"integrity": "sha512-KSwtK5Io3w8gK8kobBw86KCBkABs2EOcYMtw/cL/SFvlBvI0FVNDJsrA4FgOKf+SKK39gtsQxJ+YSExqkME1nw==",
 			"requires": {
 				"apib-include-directive": "^0.1.0",
 				"drafter.js": "^2.6.2",
@@ -247,7 +247,7 @@
 		},
 		"array-flatten": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"asn1": {
@@ -566,7 +566,7 @@
 		},
 		"content-disposition": {
 			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
 			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
 		"content-type": {
@@ -1079,7 +1079,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
@@ -1320,7 +1320,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -1827,7 +1827,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -1854,9 +1854,9 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.39.0.tgz",
-			"integrity": "sha512-DTsrw/iWVvwHH+9Otxccdyy0Tgiil6TWK/xhfARJZF/QFhwOgZgOIvA2/VIGpM8U7Q8z5nDmdDWC6tuVMJNibw=="
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
 		},
 		"mime-lookup": {
 			"version": "0.0.2",
@@ -1894,21 +1894,21 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
 			}
 		},
 		"mocha": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.3.tgz",
-			"integrity": "sha512-QdE/w//EPHrqgT5PNRUjRVHy6IJAzAf1R8n2O8W8K2RZ+NbPfOD5cBDp+PGa2Gptep37C/TdBiaNwakppEzEbg==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+			"integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "3.2.3",
@@ -1920,7 +1920,7 @@
 				"glob": "7.1.3",
 				"growl": "1.10.5",
 				"he": "1.2.0",
-				"js-yaml": "3.13.0",
+				"js-yaml": "3.13.1",
 				"log-symbols": "2.2.0",
 				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
@@ -2034,16 +2034,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.13.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-					"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
 				},
 				"lcid": {
 					"version": "2.0.0",
@@ -2230,7 +2220,7 @@
 		},
 		"multer": {
 			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
+			"resolved": "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
 			"integrity": "sha1-VRuKYBUJNwG8rMlkkWsa4GV483s=",
 			"requires": {
 				"busboy": "~0.2.9",
@@ -2241,12 +2231,12 @@
 			"dependencies": {
 				"mime-db": {
 					"version": "1.12.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+					"resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
 					"integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
 				},
 				"mime-types": {
 					"version": "2.0.14",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+					"resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
 					"integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
 					"requires": {
 						"mime-db": "~1.12.0"
@@ -2254,12 +2244,12 @@
 				},
 				"mkdirp": {
 					"version": "0.3.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+					"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
 					"integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
 				},
 				"qs": {
 					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+					"resolved": "http://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
 					"integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
 				},
 				"type-is": {
@@ -2575,7 +2565,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
@@ -2842,9 +2832,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+			"integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -3061,7 +3051,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
@@ -3300,6 +3290,11 @@
 			"version": "2.0.0-bab6bed",
 			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
 			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+		},
+		"swagger-ui-dist": {
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.1.tgz",
+			"integrity": "sha512-KITbEqXkXrjGH12A0lpVZlH3uODFkwUh8d15My1YD4N0PSZDnIiC1iMFT6ryyuJxDYWZh0qezKpPqa5FRowngw=="
 		},
 		"swagger2openapi": {
 			"version": "2.9.4",

--- a/openapi-mock/package.json
+++ b/openapi-mock/package.json
@@ -11,13 +11,14 @@
     "access": "public"
   },
   "dependencies": {
-    "api-spec-converter": "^2.8.1",
+    "api-spec-converter": "^2.8.3",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "js-yaml": "^3.13.1",
     "json-to-pretty-yaml": "^1.2.2",
     "morgan": "^1.9.1",
     "swagger-express-middleware": "^2.0.2",
+    "swagger-ui-dist": "^3.22.1",
     "winston": "^3.2.1"
   },
   "devDependencies": {
@@ -28,7 +29,7 @@
     "@types/supertest": "^2.0.7",
     "@types/swagger-express-middleware": "^1.0.9",
     "copyfiles": "^2.1.0",
-    "mocha": "^6.1.3",
+    "mocha": "^6.1.4",
     "supertest": "^4.0.2",
     "typescript": "~3.2.2"
   },

--- a/openapi-mock/src/server/app.ts
+++ b/openapi-mock/src/server/app.ts
@@ -9,6 +9,8 @@ import { logger as LOGGER } from "./logger"
 import * as morgan from "morgan"
 import * as fs from "fs"
 
+const pathToSwaggerUI = require("swagger-ui-dist").absolutePath()
+
 async function init(varkesConfigPath: string, currentDirectory = "") {
   var app = express()
 
@@ -19,6 +21,7 @@ async function init(varkesConfigPath: string, currentDirectory = "") {
   registerLogger(app);
 
   app.use(await mock(varkesConfig))
+  app.use("/swagger-ui", express.static(pathToSwaggerUI))
 
   customErrorResponses(app)
   return app;

--- a/openapi-mock/src/server/mock.ts
+++ b/openapi-mock/src/server/mock.ts
@@ -168,7 +168,7 @@ function createConsole(api: any, app: express.Application) {
     LOGGER.debug("Adding console endpoint '%s%s'", api.basepath, "/console")
     app.get(api.basepath + "/console", function (req, res) {
         var html = fs.readFileSync(__dirname + "/resources/console_template.html", 'utf8')
-        html = html.replace("OPENAPI", api.basepath + api.metadata + ".json")
+        html = html.replace("OPENAPI", api.basepath + api.metadata + ".json") //only replaces the first instance of OPENAPI.
         html = html.replace("NAME", api.name)
         res.type("text/html")
         res.status(200)

--- a/openapi-mock/src/server/resources/console_template.html
+++ b/openapi-mock/src/server/resources/console_template.html
@@ -8,21 +8,55 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-
-  <!--
-    ReDoc doesn't change outer page styles
-    -->
+  <link href="/swagger-ui/swagger-ui.css" rel="stylesheet">
+  <!--refer to app.ts to see how swagger-ui is served.-->
   <style>
+    html {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+
+    *,
+    *:before,
+    *:after {
+      box-sizing: inherit;
+    }
+
     body {
       margin: 0;
-      padding: 0;
+      background: #fafafa;
     }
   </style>
 </head>
 
 <body>
-  <redoc spec-url='OPENAPI'></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  <div id="swagger-ui"></div>
+
+  <script src="/swagger-ui/swagger-ui-bundle.js"> </script>
+  <script src="/swagger-ui/swagger-ui-standalone-preset.js"> </script>
+  <script>
+    window.onload = function () {
+      // Begin Swagger UI call region
+      // OPENAPI is replaced to basepath by createConsole() function in mock.ts
+      const ui = SwaggerUIBundle({
+        url: "OPENAPI",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+      // End Swagger UI call region
+
+      window.ui = ui
+    }
+  </script>
 </body>
 
 </html>

--- a/openapi-mock/src/server/resources/console_template.html
+++ b/openapi-mock/src/server/resources/console_template.html
@@ -38,9 +38,8 @@
   <script>
     window.onload = function () {
       // Begin Swagger UI call region
-      // OPENAPI is replaced to basepath by createConsole() function in mock.ts
       const ui = SwaggerUIBundle({
-        url: "OPENAPI",
+        url: 'OPENAPI', //replaced by basepath in mock.ts
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
This PR replaces redoc with swagger-ui which has the "try-it-out" functionality. 

A note: because the new package has an index.html, we are now serving a default swagger ui in the `swagger-ui` path.