### PR TITLE
Exception when calling single "register" - fixed scopes of variables

### DIFF
--- a/examples/combined-odata-mock/app.js
+++ b/examples/combined-odata-mock/app.js
@@ -5,8 +5,8 @@ const odataApp = require("@varkes/odata-mock")
 const cockpitApp = require("@varkes/cockpit");
 const connectorApp = require("@varkes/api-server")
 const app = require('express')()
-var runAsync = async () => {
-    var port
+let runAsync = async () => {
+    let port
     if (process.argv.length > 2 && parseInt(process.argv[2])) {
         port = process.argv[2]
     }

--- a/examples/combined-odata-mock/test.js
+++ b/examples/combined-odata-mock/test.js
@@ -78,13 +78,13 @@ describe('test app', function () {
                         .expect(200, done)
                 });
             });
-            describe('GET connection info', function () {
-                it('should return 404', function (done) {
+            describe('GET info', function () {
+                it('should return 200', function (done) {
                     request(app)
-                        .get('/connection')
+                        .get('/info')
                         .set('Accept', 'application/json')
                         .expect('Content-Type', 'application/json; charset=utf-8')
-                        .expect(404, done)
+                        .expect(200, done)
                 });
             });
 

--- a/examples/combined-openapi-mock/app.js
+++ b/examples/combined-openapi-mock/app.js
@@ -5,8 +5,8 @@ const openapiApp = require("@varkes/openapi-mock")
 const connectorApp = require("@varkes/api-server")
 const cockpitApp = require("@varkes/cockpit");
 const app = require('express')()
-var runAsync = async () => {
-    var port
+let runAsync = async () => {
+    let port
     if (process.argv.length > 2 && parseInt(process.argv[2])) {
         port = process.argv[2]
     }

--- a/examples/combined-openapi-mock/test.js
+++ b/examples/combined-openapi-mock/test.js
@@ -52,13 +52,13 @@ describe('tests odata controllers', function () {
                 });
             });
 
-            describe('GET connection info', function () {
-                it('should return 404', function (done) {
+            describe('GET info', function () {
+                it('should return 200', function (done) {
                     request(app)
-                        .get('/connection')
+                        .get('/info')
                         .set('Accept', 'application/json')
                         .expect('Content-Type', 'application/json; charset=utf-8')
-                        .expect(404, done)
+                        .expect(200, done)
                 });
             });
 

--- a/examples/kyma-mock/app.js
+++ b/examples/kyma-mock/app.js
@@ -6,8 +6,8 @@ const app = require('express')()
 const uuid = require('uuid/v4')
 const bodyParser = require('body-parser');
 
-var runAsync = async () => {
-    var port
+let runAsync = async () => {
+    let port
     if (process.argv.length > 2 && parseInt(process.argv[2])) {
         port = process.argv[2]
     }
@@ -32,7 +32,7 @@ function customizeMock(app) {
     app.use(bodyParser.json());
 
     app.get('/connector/v1/applications/signingRequests/info', function (req, res, next) {
-        var localDomain = req.protocol + "://" + req.headers.host
+        let localDomain = req.protocol + "://" + req.headers.host
 
         res.body = {
             csrUrl: localDomain + '/connector/v1/applications/certificates?token=' + "validToken",
@@ -59,7 +59,7 @@ function customizeMock(app) {
         next();
     })
     app.get("/connector/v1/applications/management/info", (req, res, next) => {
-        var localDomain = req.protocol + "://" + req.headers.host
+        let localDomain = req.protocol + "://" + req.headers.host
         res.send({
             clientIdentity: { application: 'test' },
             urls:

--- a/examples/odata-mock/app.js
+++ b/examples/odata-mock/app.js
@@ -5,7 +5,7 @@ const odataMock = require("@varkes/odata-mock")
 const app = require('express')()
 
 async function runAsync() {
-    var port
+    let port
     if (process.argv.length > 2 && parseInt(process.argv[2])) {
         port = process.argv[2]
     }

--- a/examples/openapi-mock/app.js
+++ b/examples/openapi-mock/app.js
@@ -4,8 +4,8 @@
 const openapiApp = require("@varkes/openapi-mock")
 const app = require('express')()
 
-var runAsync = async () => {
-    var port
+let runAsync = async () => {
+    let port
     if (process.argv.length > 2 && parseInt(process.argv[2])) {
         port = process.argv[2]
     }

--- a/examples/stress-mock/app.js
+++ b/examples/stress-mock/app.js
@@ -6,19 +6,19 @@ const odataApp = require("@varkes/odata-mock")
 const connectorApp = require("@varkes/api-server")
 const cockpitApp = require("@varkes/cockpit");
 const app = require('express')()
-var fs = require("fs")
+let fs = require("fs")
 
 const OPENAPI_COUNT = process.env.OPENAPI ? parseInt(process.env.OPENAPI) : 100;
 const ODATA_COUNT = process.env.ODATA ? parseInt(process.env.ODATA) : 100;
 const EVENT_COUNT = process.env.EVENT ? parseInt(process.env.EVENT) : 100;
 
-var runAsync = async () => {
-    var port
+let runAsync = async () => {
+    let port
     if (process.argv.length > 2 && parseInt(process.argv[2])) {
         port = process.argv[2]
     }
 
-    var config = generateConfig()
+    let config = generateConfig()
     if (!fs.existsSync("./generated/")) {
         fs.mkdirSync("./generated/");
     }
@@ -39,13 +39,13 @@ var runAsync = async () => {
 }
 
 function generateConfig() {
-    var config = {
+    let config = {
         name: "Stress-Mock",
         apis: [],
         events: []
     }
 
-    for (var i = 1; i < OPENAPI_COUNT + 1; i++) {
+    for (let i = 1; i < OPENAPI_COUNT + 1; i++) {
         config.apis.push({
             basepath: "/api" + i + "/v1",
             name: "OpenAPI " + i,
@@ -53,7 +53,7 @@ function generateConfig() {
             specification: "../apis/schools.yaml"
         })
     }
-    for (var i = 1; i < ODATA_COUNT + 1; i++) {
+    for (let i = 1; i < ODATA_COUNT + 1; i++) {
         config.apis.push({
             name: "OData " + i,
             specification: "../apis/services.xml",
@@ -61,7 +61,7 @@ function generateConfig() {
             type: "odata"
         })
     }
-    for (var i = 1; i < EVENT_COUNT + 1; i++) {
+    for (let i = 1; i < EVENT_COUNT + 1; i++) {
         config.events.push({
             name: "Event " + i,
             specification: "../apis/events.json"

--- a/examples/stress-mock/test.js
+++ b/examples/stress-mock/test.js
@@ -55,13 +55,13 @@ describe('tests stress apis', function () {
                 });
             });
 
-            describe('GET connection info', function () {
-                it('should return 404', function (done) {
+            describe('GET info', function () {
+                it('should return 200', function (done) {
                     request(app)
-                        .get('/connection')
+                        .get('/info')
                         .set('Accept', 'application/json')
                         .expect('Content-Type', 'application/json; charset=utf-8')
-                        .expect(404, done)
+                        .expect(200, done)
                 });
             });
 

--- a/modules/api-server/src/server/app.ts
+++ b/modules/api-server/src/server/app.ts
@@ -25,9 +25,9 @@ const pathToSwaggerUI = require("swagger-ui-dist").absolutePath()
 
 async function init(varkesConfigPath: string, currentPath = "") {
 
-    var varkesConfig = config.init(varkesConfigPath, currentPath)
+    let varkesConfig = config.init(varkesConfigPath, currentPath)
 
-    var app = express()
+    let app = express()
     app.use(bodyParser.json())
     app.use(cors())
     app.options('*', cors())
@@ -41,7 +41,7 @@ async function init(varkesConfigPath: string, currentPath = "") {
 
     app.get("/info", function (req, res) {
 
-        var info = {
+        let info = {
             appName: varkesConfig.name,
             links: {
                 logo: LOGO_URL,
@@ -55,7 +55,7 @@ async function init(varkesConfigPath: string, currentPath = "") {
         res.status(200).send(info);
     });
     app.get(LOGO_URL, function (req, res) {
-        var img = fs.readFileSync(varkesConfig.logo || VARKES_LOGO)
+        let img = fs.readFileSync(varkesConfig.logo || VARKES_LOGO)
         res.writeHead(200, { 'Content-Type': "image/svg+xml" })
         res.end(img, 'binary')
     })

--- a/modules/api-server/src/server/config.ts
+++ b/modules/api-server/src/server/config.ts
@@ -9,9 +9,9 @@ const yaml = require("js-yaml");
 const pretty_yaml = require('json-to-pretty-yaml')
 
 function init(varkesConfigPath: string, currentDirectory: any) {
-    var varkesConfig
+    let varkesConfig
     if (varkesConfigPath) {
-        var endpointConfig = path.resolve(currentDirectory, varkesConfigPath)
+        let endpointConfig = path.resolve(currentDirectory, varkesConfigPath)
         LOGGER.info("Using configuration %s", endpointConfig)
         varkesConfig = JSON.parse(fs.readFileSync(endpointConfig, "utf-8"))
         varkesConfig.apis.map((element: any) => {
@@ -29,13 +29,13 @@ function init(varkesConfigPath: string, currentDirectory: any) {
 }
 
 function configValidation(configJson: any) {
-    var error_message = ""
-    var events = configJson.events
-    var apis = configJson.apis
+    let error_message = ""
+    let events = configJson.events
+    let apis = configJson.apis
     if (events) {
-        for (var i = 1; i <= events.length; i++) {
+        for (let i = 1; i <= events.length; i++) {
             {
-                var event = events[i - 1]
+                let event = events[i - 1]
                 if (!event.name) {
                     error_message += "\nevent number " + i + ": missing attribute 'name', a name is mandatory"
                 }
@@ -46,7 +46,7 @@ function configValidation(configJson: any) {
                     error_message += "\nevent '" + event.name + "': specification '" + event.specification + "' does not match pattern '^.+\\.(json|yaml|yml)$'"
                 }
                 else {
-                    var specInJson
+                    let specInJson
                     if (event.specification.endsWith(".json")) {
                         specInJson = JSON.parse(fs.readFileSync(event.specification, 'utf8'))
                     } else {
@@ -62,8 +62,8 @@ function configValidation(configJson: any) {
         }
     }
     if (apis) {
-        for (var i = 1; i <= apis.length; i++) {
-            var api = apis[i - 1]
+        for (let i = 1; i <= apis.length; i++) {
+            let api = apis[i - 1]
             if (api.auth && !(api.auth == "oauth" || api.auth == "none" || api.auth == "basic")) {
                 error_message += "\napi " + (api.name ? api.name : "number " + i) + ": attribute 'auth' should be one of three values [oauth, basic, none]";
             }

--- a/modules/api-server/src/server/routes/connector.ts
+++ b/modules/api-server/src/server/routes/connector.ts
@@ -16,7 +16,7 @@ function disconnect(req: any, res: any) {
 }
 
 function info(req: any, res: any) {
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(404).send({ error: err })
     } else {
@@ -25,7 +25,7 @@ function info(req: any, res: any) {
 }
 
 function key(req: any, res: any) {
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -37,7 +37,7 @@ function key(req: any, res: any) {
 }
 
 function cert(req: any, res: any) {
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -70,7 +70,7 @@ async function connect(req: any, res: any) {
         }
         else {
             if (error.statusCode == 403) {
-                var message = "Error: Invalid Token, Please use another Token"
+                let message = "Error: Invalid Token, Please use another Token"
                 res.status(error.statusCode).send(message);
             }
             else {
@@ -82,7 +82,7 @@ async function connect(req: any, res: any) {
 }
 
 function router() {
-    var connectionRouter = express.Router()
+    let connectionRouter = express.Router()
     connectionRouter.get("/", info)
     connectionRouter.delete("/", disconnect)
     connectionRouter.get(connection.KEY_URL, key)

--- a/modules/api-server/src/server/routes/events.ts
+++ b/modules/api-server/src/server/routes/events.ts
@@ -7,7 +7,7 @@ import { event, connection } from "@varkes/app-connector"
 
 function sendEvent(req: any, res: any) {
     LOGGER.debug("Sending event %s", JSON.stringify(req.body, null, 2))
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -20,7 +20,7 @@ function sendEvent(req: any, res: any) {
 }
 
 function router() {
-    var eventsRouter = express.Router()
+    let eventsRouter = express.Router()
     eventsRouter.post("/", sendEvent)
     return eventsRouter
 }

--- a/modules/api-server/src/server/routes/localApis.ts
+++ b/modules/api-server/src/server/routes/localApis.ts
@@ -6,17 +6,17 @@ import { api, connection } from "@varkes/app-connector"
 var varkesConfig: any;
 function getAll(req: any, res: any) {
     LOGGER.debug("Getting all Local APIs")
-    var apis = []
-    var configApis = varkesConfig.apis;
-    for (var i = 0; i < configApis.length; i++) {
-        var api = configApis[i]
+    let apis = []
+    let configApis = varkesConfig.apis;
+    for (let i = 0; i < configApis.length; i++) {
+        let api = configApis[i]
         let metadata: any = services.fillServiceMetadata(api, getOrigin(req))
         metadata.id = api.name
         apis.push(metadata)
     }
-    var configEvents = varkesConfig.events;
-    for (var i = 0; i < configEvents.length; i++) {
-        var event = configEvents[i];
+    let configEvents = varkesConfig.events;
+    for (let i = 0; i < configEvents.length; i++) {
+        let event = configEvents[i];
         let metadata: any = services.fillEventData(event)
         metadata.id = event.name;
         apis.push(metadata);
@@ -55,7 +55,7 @@ function getOrigin(req: any) {
 
 async function registerAll(req: any, res: any) {
     LOGGER.debug("Registering all Local APIs")
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     }
@@ -66,7 +66,7 @@ async function registerAll(req: any, res: any) {
         res.status(200).send(connection.info())
     }
     catch (error) {
-        var message = "There is an error while registering all APIs."
+        let message = "There is an error while registering all APIs."
         LOGGER.error("Failed to register all APIs: %s", error.stack)
         res.status(500).send({ error: message })
     }
@@ -78,7 +78,7 @@ function getStatus(req: any, res: any) {
 async function create(req: any, res: any) {
     LOGGER.debug("Create Local API %s", req.params.apiname)
 
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -87,23 +87,23 @@ async function create(req: any, res: any) {
         let events = varkesConfig.events;
         let apiFound = false;
         let serviceMetadata: any;
-        for (var i = 0; i < apis.length; i++) {
-            var api = apis[i];
-            if (api.name == apiName) {
-                serviceMetadata = services.fillServiceMetadata(api, getOrigin(req));
+        for (let i = 0; i < apis.length; i++) {
+            let apiEntry = apis[i];
+            if (apiEntry.name == apiName) {
+                serviceMetadata = services.fillServiceMetadata(apiEntry, getOrigin(req));
                 apiFound = true;
                 break;
             }
         }
-        for (var i = 0; i < events.length && !apiFound; i++) {
-            var event = events[i];
+        for (let i = 0; i < events.length && !apiFound; i++) {
+            let event = events[i];
             if (event.name == apiName) {
                 serviceMetadata = services.fillEventData(event);
                 break;
             }
         }
-        var registeredAPIs = await api.findAll();
-        var reg_api;
+        let registeredAPIs = await api.findAll();
+        let reg_api;
         if (registeredAPIs.length > 0)
             reg_api = registeredAPIs.find((x: any) => x.name == serviceMetadata.name)
         if (!reg_api) {
@@ -119,7 +119,7 @@ async function create(req: any, res: any) {
             }, (err: any) => {
                 res.status(err.statusCode).send(err.message);
             })
-            LOGGER.debug("Updated API successful: %s", api.name)
+            LOGGER.debug("Updated API successful: %s", apiName)
         }
 
     }
@@ -131,7 +131,7 @@ function assureConnected() {
     return null
 }
 function router(config: any) {
-    var apiRouter = express.Router()
+    let apiRouter = express.Router()
     varkesConfig = config
     apiRouter.get("/apis", getAll)
     apiRouter.post("/registration", registerAll)

--- a/modules/api-server/src/server/routes/remoteApis.ts
+++ b/modules/api-server/src/server/routes/remoteApis.ts
@@ -9,7 +9,7 @@ import { api, connection } from "@varkes/app-connector"
 
 function getAll(req: any, res: any) {
     LOGGER.debug("Getting all APIs")
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -23,7 +23,7 @@ function getAll(req: any, res: any) {
 
 function get(req: any, res: any) {
     LOGGER.debug("Get API %s", req.params.api)
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -49,7 +49,7 @@ function get(req: any, res: any) {
 
 function update(req: any, res: any) {
     LOGGER.debug("Update API %s", req.params.api)
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -63,7 +63,7 @@ function update(req: any, res: any) {
 
 function deleteApi(req: any, res: any) {
     LOGGER.debug("Delete API %s", req.params.api)
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -76,7 +76,7 @@ function deleteApi(req: any, res: any) {
 }
 function create(req: any, res: any) {
     LOGGER.debug("Creating API %s", req.body.name)
-    var err = assureConnected()
+    let err = assureConnected()
     if (err) {
         res.status(400).send({ error: err })
     } else {
@@ -116,7 +116,7 @@ function dereferenceApi(body: any) {
 
 }
 function router() {
-    var apiRouter = express.Router()
+    let apiRouter = express.Router()
 
     apiRouter.get("/", getAll)
     apiRouter.post("/", create)

--- a/modules/api-server/src/server/services.ts
+++ b/modules/api-server/src/server/services.ts
@@ -21,9 +21,9 @@ async function createServicesFromConfig(baseUrl: any, varkesConfig: any, registe
     apisCount = 0;
     apisCount += varkesConfig.apis.length;
     regErrorMessage = "";
-    for (var i = 0; i < varkesConfig.apis.length; i++) {
+    for (let i = 0; i < varkesConfig.apis.length; i++) {
         let varkesApi = varkesConfig.apis[i];
-        var reg_api
+        let reg_api
         if (registeredApis.length > 0)
             reg_api = registeredApis.find((x: any) => x.name == varkesApi.name)
         try {
@@ -42,22 +42,22 @@ async function createServicesFromConfig(baseUrl: any, varkesConfig: any, registe
         catch (err) {
             if (!reg_api) {
                 apisFailedCount++;
-                var message = "Registration of API '" + varkesApi.name + "' failed: " + JSON.stringify(err.message);
+                let message = "Registration of API '" + varkesApi.name + "' failed: " + JSON.stringify(err.message);
                 regErrorMessage += message + "\n";
                 LOGGER.error(message)
             }
             else {
                 apisFailedCount++;
-                var message = "Updating API '" + varkesApi.name + "' failed: " + JSON.stringify(err.message);
+                let message = "Updating API '" + varkesApi.name + "' failed: " + JSON.stringify(err.message);
                 regErrorMessage += "- " + message + "\n\n";
                 LOGGER.error(message)
             }
         }
     }
     apisCount += varkesConfig.events.length;
-    for (var i = 0; i < varkesConfig.events.length; i++) {
+    for (let i = 0; i < varkesConfig.events.length; i++) {
         let event = varkesConfig.events[i];
-        var reg_api;
+        let reg_api;
         if (registeredApis.length > 0)
             reg_api = registeredApis.find((x: any) => x.name == event.name)
         try {
@@ -76,13 +76,13 @@ async function createServicesFromConfig(baseUrl: any, varkesConfig: any, registe
         catch (err) {
             if (!reg_api) {
                 apisFailedCount++;
-                var message = "Registration of Event '" + event.name + "' failed: " + JSON.stringify(err.message);
+                let message = "Registration of Event '" + event.name + "' failed: " + JSON.stringify(err.message);
                 regErrorMessage += message + "\n";
                 LOGGER.error(message)
             }
             else {
                 apisFailedCount++;
-                var message = "Registration of Event '" + event.name + "' failed: " + JSON.stringify(err.message);
+                let message = "Registration of Event '" + event.name + "' failed: " + JSON.stringify(err.message);
                 regErrorMessage += message + "\n";
                 LOGGER.error(message)
             }
@@ -101,7 +101,7 @@ function getStatus() {
 }
 
 function fillEventData(event: any) {
-    var specInJson
+    let specInJson
     if (event.specification.endsWith(".json")) {
         specInJson = JSON.parse(fs.readFileSync(event.specification, 'utf8'))
     } else {
@@ -109,7 +109,7 @@ function fillEventData(event: any) {
     }
     let labels = event.labels ? event.labels : {};
     labels["type"] = "AsyncApi";
-    var serviceData = {
+    let serviceData = {
         provider: event.provider ? event.provider : "Varkes",
         name: event.name,
         description: event.description ? event.description : event.name,
@@ -168,7 +168,7 @@ function fillServiceMetadata(api: any, baseUrl: any) {
     }
 
     if (!api.type || api.type == "openapi") {
-        var specInJson
+        let specInJson
         if (api.specification.endsWith(".json")) {
             specInJson = JSON.parse(fs.readFileSync(api.specification, 'utf8'))
         } else {
@@ -188,7 +188,7 @@ function fillServiceMetadata(api: any, baseUrl: any) {
     }
     let labels = api.labels ? api.labels : {};
     labels["type"] = api.type == "odata" ? "OData" : "OpenAPI"
-    var serviceData = {
+    let serviceData = {
         provider: api.provider ? api.provider : "Varkes",
         name: api.name,
         description: api.description ? api.description : api.name,

--- a/modules/api-server/src/test/test_integration.ts
+++ b/modules/api-server/src/test/test_integration.ts
@@ -18,8 +18,8 @@ const port = 10001 //! listen in different port
 const tokenURL = `http://localhost:${port}/connector/v1/applications/signingRequests/info?token=123`
 
 describe("should work", () => {
-    var kymaServer: any
-    var server: any
+    let kymaServer: any
+    let server: any
     before(async () => { //* start kyma mock before tests
         await kyma.then((app: any) => {
             kymaServer = app.listen(port)

--- a/modules/app-connector/src/server/api.ts
+++ b/modules/app-connector/src/server/api.ts
@@ -9,7 +9,7 @@ export class API {
         }
         return null
     }
-    public findAll() {
+    public findAll():Promise<any[]> {
         return new Promise((resolve, reject) => {
             let err = this.assureConnected()
             if (err) {

--- a/modules/app-connector/src/test/test.ts
+++ b/modules/app-connector/src/test/test.ts
@@ -17,7 +17,7 @@ const eventAPI = fs.readFileSync(path.resolve("dist/test/event.json")).toString(
 const eventPublishAPI = fs.readFileSync(path.resolve("dist/test/eventPublish.json")).toString();
 const eventResponseExpected = fs.readFileSync(path.resolve("dist/test/expect/event.json")).toString();
 describe("should work", () => {
-    var kymaServer: any
+    let kymaServer: any
     before(async () => { //* start kyma mock before tests
         deleteKeysFile()
         await kyma.then((app: any) => {

--- a/modules/app-connector/src/tools/cli.js
+++ b/modules/app-connector/src/tools/cli.js
@@ -72,7 +72,7 @@ function createServicesFromConfig(hostname, endpoints) {
 
 function createSingleService(hostname, endpoints, endpointCount) {
 
-    var element = endpoints.apis[endpointCount]
+    let element = endpoints.apis[endpointCount]
     serviceMetadata.name = endpoints.name + "-" + Math.random().toString(36).substring(2, 5);
     serviceMetadata.api.targetUrl = hostname + element.basepath
     serviceMetadata.api.credentials.oauth.url = hostname + element.oauth

--- a/modules/odata-mock/src/server/app.ts
+++ b/modules/odata-mock/src/server/app.ts
@@ -11,11 +11,11 @@ import * as parser from "./parser"
 const path = require("path")
 
 async function init(varkesConfigPath: string, currentPath = "") {
-  var varkesConfig = config(varkesConfigPath, currentPath)
+  let varkesConfig = config(varkesConfigPath, currentPath)
 
-  var promises: Promise<any>[] = [];
-  for (var i = 0; i < varkesConfig.apis.length; i++) {
-    var api = varkesConfig.apis[i]
+  let promises: Promise<any>[] = [];
+  for (let i = 0; i < varkesConfig.apis.length; i++) {
+    let api = varkesConfig.apis[i]
     if (api.type == "odata") {
       promises.push(bootLoopback(api, varkesConfig))
     }
@@ -23,7 +23,7 @@ async function init(varkesConfigPath: string, currentPath = "") {
 
   let resultApp = express()
   let apps = await Promise.all(promises)
-  for (var i = 0; i < apps.length; i++) {
+  for (let i = 0; i < apps.length; i++) {
     resultApp.use(apps[i])
   }
 
@@ -31,12 +31,12 @@ async function init(varkesConfigPath: string, currentPath = "") {
 }
 
 async function bootLoopback(api: any, varkesConfig: any) {
-  var app = loopback();
+  let app = loopback();
   app.use(bodyParser.json());
   app.varkesConfig = varkesConfig
 
   LOGGER.debug("Parsing specification and generating models for api %s", api.name)
-  var bootConfig = await generateBootConfig(api)
+  let bootConfig = await generateBootConfig(api)
 
   LOGGER.debug("Booting loopback middleware for api %s", api.name)
 
@@ -53,10 +53,10 @@ async function bootLoopback(api: any, varkesConfig: any) {
 
 async function generateBootConfig(api: any) {
   let dataSourceName = api.name.replace(/\s/g, '')
-  var parsedModel = await parser.parseEdmx(api.specification, dataSourceName)
+  let parsedModel = await parser.parseEdmx(api.specification, dataSourceName)
 
   //for configuration, see https://apidocs.strongloop.com/loopback-boot/
-  var bootConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, "resources/boot_config_template.json"), "utf-8"))
+  let bootConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, "resources/boot_config_template.json"), "utf-8"))
 
   parsedModel.modelConfigs.forEach(function (config: any) {
     bootConfig.models[config.name] = config.value

--- a/modules/odata-mock/src/server/config.ts
+++ b/modules/odata-mock/src/server/config.ts
@@ -7,9 +7,9 @@ import { logger as LOGGER } from "./logger"
 import { VarkesConfigType } from "./types";
 
 function config(varkesConfigPath: string, currentPath: string): VarkesConfigType {
-    var varkesConfig
+    let varkesConfig
     if (varkesConfigPath) {
-        var endpointConfig = path.resolve(currentPath, varkesConfigPath)
+        let endpointConfig = path.resolve(currentPath, varkesConfigPath)
         LOGGER.info("Using configuration %s", endpointConfig)
         varkesConfig = JSON.parse(fs.readFileSync(endpointConfig, "utf-8"))
         varkesConfig.apis.map((api: any) => {
@@ -24,10 +24,10 @@ function config(varkesConfigPath: string, currentPath: string): VarkesConfigType
 }
 
 function configValidation(configJson: VarkesConfigType) {
-    var error_message = "";
+    let error_message = "";
     if (configJson.hasOwnProperty("apis")) {
-        for (var i = 1; i <= configJson.apis.length; i++) {
-            var api = configJson.apis[i - 1];
+        for (let i = 1; i <= configJson.apis.length; i++) {
+            let api = configJson.apis[i - 1];
             if (!api.name) {
                 error_message += "\napi number " + i + ": missing attribute 'name', a name is mandatory";
             }

--- a/modules/odata-mock/src/server/routes.ts
+++ b/modules/odata-mock/src/server/routes.ts
@@ -8,10 +8,10 @@ const fs = require('fs');
 
 module.exports = function (app: any) {
     registerLogger(app);
-    var apis = app.varkesConfig.apis;
+    let apis = app.varkesConfig.apis;
 
     function modifyResponseBody(req: any, res: any, next: any) {
-        var oldSend = res.send;
+        let oldSend = res.send;
 
         res.send = function (data: any) {
             if (!arguments[0] && arguments[0].statusCode) {
@@ -45,8 +45,8 @@ module.exports = function (app: any) {
             else
                 return "-";
         });
-        var logging_string = '[:date[clf]], User: :remote-user, ":method :url, Status: :status"\n Header:\n :header\n Body:\n :body'
-        var requestLogStream = fs.createWriteStream('requests.log', { flags: 'a' })
+        let logging_string = '[:date[clf]], User: :remote-user, ":method :url, Status: :status"\n Header:\n :header\n Body:\n :body'
+        let requestLogStream = fs.createWriteStream('requests.log', { flags: 'a' })
         app.use(morgan(logging_string, { stream: requestLogStream }), morgan(logging_string))
     }
 

--- a/modules/odata-mock/src/server/server.ts
+++ b/modules/odata-mock/src/server/server.ts
@@ -6,7 +6,7 @@ const app = require('express')()
 import { logger as LOGGER } from "./logger"
 
 var runAsync = async () => {
-    var configPath: string = ""
+    let configPath: string = ""
     if (process.argv.length > 2) {
 
         configPath = process.argv[2]

--- a/modules/odata-mock/src/test/test.ts
+++ b/modules/odata-mock/src/test/test.ts
@@ -8,7 +8,7 @@ const express = require('express')
 describe('test app', function () {
     it('should work', (done) => {
         mock('./varkes_config.json', __dirname).then((mock: any) => {
-            var app = express()
+            let app = express()
             app.use(mock)
 
             describe('GET Advertisements via API', function () {

--- a/modules/openapi-mock/src/server/app.ts
+++ b/modules/openapi-mock/src/server/app.ts
@@ -12,9 +12,9 @@ import * as fs from "fs"
 const pathToSwaggerUI = require("swagger-ui-dist").absolutePath()
 
 async function init(varkesConfigPath: string, currentDirectory = "") {
-  var app = express()
+  let app = express()
 
-  var varkesConfig = configure(varkesConfigPath, currentDirectory);
+  let varkesConfig = configure(varkesConfigPath, currentDirectory);
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }))
 
@@ -40,11 +40,11 @@ function registerLogger(app: express.Application) {
     else
       return "-";
   });
-  var logging_string = '[:date[clf]], User: :remote-user, ":method :url, Status: :status"\n Header:\n :header\n Body:\n :body'
-  var requestLogStream = fs.createWriteStream('requests.log', { flags: 'a' })
+  let logging_string = '[:date[clf]], User: :remote-user, ":method :url, Status: :status"\n Header:\n :header\n Body:\n :body'
+  let requestLogStream = fs.createWriteStream('requests.log', { flags: 'a' })
   app.use(morgan(logging_string, { stream: requestLogStream }), morgan(logging_string))
   app.get('/requests', function (req, res, done) {
-    var text = fs.readFileSync("requests.log", "utf8");
+    let text = fs.readFileSync("requests.log", "utf8");
     res.status(200);
     res.send(text);
   });

--- a/modules/openapi-mock/src/server/config.ts
+++ b/modules/openapi-mock/src/server/config.ts
@@ -9,9 +9,9 @@ const OAUTH = "/authorizationserver/oauth/token";
 const METADATA = "/metadata";
 
 function configure(varkesConfigPath: string, currentDirectory: string) {
-    var varkesConfig
+    let varkesConfig
     if (varkesConfigPath) {
-        var endpointConfig = path.resolve(currentDirectory, varkesConfigPath)
+        let endpointConfig = path.resolve(currentDirectory, varkesConfigPath)
         LOGGER.info("Using configuration %s", endpointConfig)
         varkesConfig = JSON.parse(fs.readFileSync(endpointConfig, "utf-8"))
         varkesConfig.apis.map((api: any) => {
@@ -32,10 +32,10 @@ function configure(varkesConfigPath: string, currentDirectory: string) {
 }
 
 function configValidation(configJson: any) {
-    var error_message = "";
+    let error_message = "";
     if (configJson.hasOwnProperty("apis")) {
-        for (var i = 1; i <= configJson.apis.length; i++) {
-            var api = configJson.apis[i - 1];
+        for (let i = 1; i <= configJson.apis.length; i++) {
+            let api = configJson.apis[i - 1];
             if (!api.name) {
                 error_message += "\napi number " + i + ": missing attribute 'name', a name is mandatory";
             }

--- a/modules/openapi-mock/src/server/mock.ts
+++ b/modules/openapi-mock/src/server/mock.ts
@@ -14,21 +14,21 @@ const DIR_NAME = "./generated/";
 const TMP_FILE = "tmp.yaml";
 
 async function mock(config: any) {
-    var resultApp = express()
-    var error_message = "";
-    for (var i = 0; i < config.apis.length; i++) {
-        var api = config.apis[i];
+    let resultApp = express()
+    let error_message = "";
+    for (let i = 0; i < config.apis.length; i++) {
+        let api = config.apis[i];
         if (!api.type || api.type == "openapi") {
             try {
                 let app = express()
                 createOauthEndpoint(api, app);
                 createConsole(api, app);
 
-                var spec = loadSpec(api)
+                let spec = loadSpec(api)
                 if (spec.openapi) {
-                    var jsonSpec = await transformSpec(api)
+                    let jsonSpec = await transformSpec(api)
 
-                    var specString = jsonSpec.stringify({ syntax: "yaml" })
+                    let specString = jsonSpec.stringify({ syntax: "yaml" })
                     writeSpec(specString, api, i)
                     spec = loadSpec(api)
                 }
@@ -50,7 +50,7 @@ async function mock(config: any) {
                     myDB = new middleware.FileDataStore("./data");
                 }
 
-                var middlewares = [];
+                let middlewares = [];
                 middlewares.push(
                     middleware(api.specification, app, (_err: Error, middleware: SwaggerMiddleware) => {
                         app.use(
@@ -66,7 +66,7 @@ async function mock(config: any) {
                 resultApp.use(app)
             }
             catch (err) {
-                var message = "Serving API " + api.name + " failed: " + err.message
+                let message = "Serving API " + api.name + " failed: " + err.message
                 LOGGER.error(message)
                 error_message += "\n" + message
             }
@@ -84,7 +84,7 @@ function loadSpec(api: any) {
 }
 
 function writeSpec(specString: string, api: any, index: any) {
-    var file_name = DIR_NAME + index + "_" + TMP_FILE;
+    let file_name = DIR_NAME + index + "_" + TMP_FILE;
     LOGGER.debug("Writing api '%s' to file '%s' and length %d", api.name, file_name, specString.length);
 
     if (!fs.existsSync(DIR_NAME)) {
@@ -100,7 +100,7 @@ function createEndpoints(spec: any, api: any) {
     if (api.hasOwnProperty("added_endpoints")) {
         LOGGER.debug("Adding new Endpoints for api '%s'", api.name);
         api.added_endpoints.forEach((point: any) => {
-            var endpoint = yaml.safeLoad(fs.readFileSync(point.filePath, 'utf8'));
+            let endpoint = yaml.safeLoad(fs.readFileSync(point.filePath, 'utf8'));
             if (!spec["paths"].hasOwnProperty(point.url)) {
                 LOGGER.debug("Adding custom endpoint '%s' to '%s'", point.url, api.name)
                 spec["paths"][point.url] = endpoint;
@@ -117,7 +117,7 @@ function createOauthEndpoint(api: any, app: express.Application) {
             res.send({ token: 3333 });
         }
         else {
-            var message = "Some of the required parameters are missing";
+            let message = "Some of the required parameters are missing";
             res.status(400);
             res.send({ error: message });
         }
@@ -167,7 +167,7 @@ function createMetadataEndpoint(spec: any, api: any, app: express.Application) {
 function createConsole(api: any, app: express.Application) {
     LOGGER.debug("Adding console endpoint '%s%s'", api.basepath, "/console")
     app.get(api.basepath + "/console", function (req, res) {
-        var html = fs.readFileSync(__dirname + "/resources/console_template.html", 'utf8')
+        let html = fs.readFileSync(__dirname + "/resources/console_template.html", 'utf8')
         html = html.replace("OPENAPI", api.basepath + api.metadata + ".json") //only replaces the first instance of OPENAPI.
         html = html.replace("NAME", api.name)
         res.type("text/html")

--- a/modules/openapi-mock/src/test/test.ts
+++ b/modules/openapi-mock/src/test/test.ts
@@ -9,7 +9,7 @@ import * as express from "express"
 describe('controllers', function () {
   it('should work', function (done) {
     mock.init('varkes_config.json', __dirname).then(function (mock: any) {
-      var app = express()
+      let app = express()
       app.get('/api1/pets/:petId', (req: any, res: any, next: any) => {
         res.body = {
           success: req.params.petId


### PR DESCRIPTION
When pushing the "Register" button or calling the /local/apis/x/register API you get:

```
(node:16) UnhandledPromiseRejectionWarning: TypeError: api.findAll is not a function
    at /app/node_modules/@varkes/api-server/dist/server/routes/localApis.js:158:46
    at step (/app/node_modules/@varkes/api-server/dist/server/routes/localApis.js:32:23)
```
The cockpit is hanging then.

The problem was caused by overwriting a variable accidently. To avoid this in future I adjusted all usage of "var" to "let" for variable declaration. With that the scope of a variable is always on block level.