### PR TITLE
add dummy commands

### DIFF
--- a/modules/app-connector/Makefile
+++ b/modules/app-connector/Makefile
@@ -7,5 +7,7 @@ validate:
 clean:
 	rm -rf ./node_modules
 
+docker-build: ;
+docker-push: ;
 run:
 	npm start


### PR DESCRIPTION
Not having a build command causes make to exit with error which stops lerna from executing future commands. I added these dummy commands to our only module which doesn't have a dockerfile so make command wont exit with error.  