### PR TITLE
removed error response modification as it is useless

### DIFF
--- a/modules/api-server/src/test/varkes_config.json
+++ b/modules/api-server/src/test/varkes_config.json
@@ -1,9 +1,4 @@
 {
-    "error_messages": {
-        "500": "{\"error\":\"Something went Wrong\"}",
-        "400": "{\"error\":\"Errorrrr\"}",
-        "404": "{\"error\":\"End Point not found\"}"
-    },
     "name": "app-connector-mock",
     "logo": "../../assets/logo.svg",
     "events": [

--- a/modules/odata-mock/src/server/routes.ts
+++ b/modules/odata-mock/src/server/routes.ts
@@ -10,28 +10,6 @@ module.exports = function (app: any) {
     registerLogger(app);
     let apis = app.varkesConfig.apis;
 
-    function modifyResponseBody(req: any, res: any, next: any) {
-        let oldSend = res.send;
-
-        res.send = function (data: any) {
-            if (!arguments[0] && arguments[0].statusCode) {
-                arguments[0] = {};
-                arguments[0].statusCode = 500;
-            }
-            if (app.varkesConfig.hasOwnProperty("error_messages")) {
-                if (app.varkesConfig.error_messages.hasOwnProperty(arguments[0].statusCode)) {
-                    LOGGER.debug("Modifying error response with status code '%s'", arguments[0].statusCode)
-                    arguments[0] = app.varkesConfig.error_messages[arguments[0].statusCode];
-                }
-                else if (app.varkesConfig.error_messages.hasOwnProperty(arguments[0])) {
-                    arguments[0] = app.varkesConfig.error_messages[arguments[0]];
-                }
-            }
-            oldSend.apply(res, arguments);
-        }
-        next();
-    }
-
     function registerLogger(app: any) {
         morgan.token('header', function (req: any, res: any) {
             if (req.rawHeaders && Object.keys(req.rawHeaders).length != 0)
@@ -50,6 +28,5 @@ module.exports = function (app: any) {
         app.use(morgan(logging_string, { stream: requestLogStream }), morgan(logging_string))
     }
 
-    app.use(modifyResponseBody);
     app.use(bodyParser.json());
 }


### PR DESCRIPTION
In the odata-mock there was a leftover of a feature to customize the default error response.
The feature was not used anymore and undocumented so I removed it.
The feature caused a null pointer on disconnect feature of api-server