### PR TITLE
Prefer origin header if available

### DIFF
--- a/modules/api-server/.npmignore
+++ b/modules/api-server/.npmignore
@@ -1,7 +1,6 @@
-Dockerfile
 .dockerignore
+Dockerfile
 node_modules
 Makefile
 *.log
-keys/.*
-.nyc_output
+src

--- a/modules/api-server/src/server/routes/connector.ts
+++ b/modules/api-server/src/server/routes/connector.ts
@@ -2,9 +2,13 @@
 'use strict'
 
 import * as config from "@varkes/configuration"
-const LOGGER = config.logger("api-server")
 import * as express from "express"
 import { connection } from "@varkes/app-connector"
+
+const LOGGER = config.logger("api-server")
+const KEY_URL = "/key"
+const CERT_URL = "/cert"
+
 
 function disconnect(req: express.Request, res: express.Response) {
     try {
@@ -21,7 +25,10 @@ function info(req: express.Request, res: express.Response) {
     if (err) {
         res.status(404).send({ error: err })
     } else {
-        res.status(200).send(connection.info())
+        let body: any = connection.info()
+        body.cert = CERT_URL
+        body.key = KEY_URL
+        res.status(200).send(body)
     }
 }
 
@@ -71,8 +78,8 @@ function router() {
     let connectionRouter = express.Router()
     connectionRouter.get("/", info)
     connectionRouter.delete("/", disconnect)
-    connectionRouter.get("/key", key)
-    connectionRouter.get("/cert", cert)
+    connectionRouter.get(KEY_URL, key)
+    connectionRouter.get(CERT_URL, cert)
     connectionRouter.post("/", connect)
 
     return connectionRouter

--- a/modules/api-server/src/server/routes/localApis.ts
+++ b/modules/api-server/src/server/routes/localApis.ts
@@ -54,7 +54,7 @@ function getOrigin(req: express.Request) {
     if (req.body.baseUrl && !req.body.baseUrl.match(/http(s)?:\/\//)) {
         return req.protocol + req.body.baseUrl
     }
-    return req.body.baseUrl || req.protocol + "://" + req.headers.host
+    return req.body.baseUrl || req.headers.origin || req.protocol + "://" + req.headers.host
 }
 
 async function registerAll(req: express.Request, res: express.Response) {

--- a/modules/configuration/.npmignore
+++ b/modules/configuration/.npmignore
@@ -1,3 +1,5 @@
+.dockerignore
+Dockerfile
 node_modules
 Makefile
 *.log


### PR DESCRIPTION
At registration time via the cockpit of varkes somehow the protocol function of the express request is providing the wrong value (http instead of https). Prefer the origin header over the self-constructed origin URL.