### PR TITLE
fixing encoding problems

### DIFF
--- a/modules/app-connector/src/server/common.ts
+++ b/modules/app-connector/src/server/common.ts
@@ -15,9 +15,9 @@ export function assureConnected(connection: any): Promise<boolean> {
     })
 }
 
-export function generateCSR(subject: any, privateKey: string) {
+export function generateCSR(subject: any, privateKey: Buffer):Buffer {
     LOGGER.debug("Creating CSR using subject %s", subject)
-    let pk = forge.pki.privateKeyFromPem(privateKey)
+    let pk = forge.pki.privateKeyFromPem(privateKey.toString())
     let publickey = forge.pki.setRsaPublicKey(pk.n, pk.e)
 
     // create a certification request (CSR)
@@ -27,7 +27,7 @@ export function generateCSR(subject: any, privateKey: string) {
     csr.setSubject(parseSubjectToJsonArray(subject))
     csr.sign(pk)
     LOGGER.debug("Created csr using subject %s", subject)
-    return forge.pki.certificationRequestToPem(csr)
+    return Buffer.from(forge.pki.certificationRequestToPem(csr))
 }
 
 function parseSubjectToJsonArray(subject: any) {

--- a/modules/app-connector/src/server/compass/common.ts
+++ b/modules/app-connector/src/server/compass/common.ts
@@ -51,7 +51,7 @@ export function createDirectorClient(): ApolloClient<NormalizedCacheObject> {
     return createDirectorClientWithInfo(connection.info()!, connection.certificate())
 }
 
-export function createDirectorClientWithInfo(connectionInfo: connection.Info, certificate: string): ApolloClient<NormalizedCacheObject> {
+export function createDirectorClientWithInfo(connectionInfo: connection.Info, certificate: Buffer): ApolloClient<NormalizedCacheObject> {
     let authLink = setContext((_, { headers }) => {
         return {
             headers: {

--- a/modules/app-connector/src/server/connection.ts
+++ b/modules/app-connector/src/server/connection.ts
@@ -14,8 +14,8 @@ const connFile = path.resolve(keysDirectory, "connection.json")
 const crtFile = path.resolve(keysDirectory, "kyma.crt")
 const privateKeyFile = path.resolve(keysDirectory, "app.key")
 
-var privateKeyData: string;
-var certificateData: string;
+var privateKeyData: Buffer;
+var certificateData: Buffer;
 var connection: Info | null = null;
 
 export function init() {
@@ -24,24 +24,24 @@ export function init() {
     }
 
     if (fs.existsSync(privateKeyFile)) {
-        privateKeyData = fs.readFileSync(privateKeyFile, "utf-8")
+        privateKeyData = fs.readFileSync(privateKeyFile)
         LOGGER.info("Found existing private key: %s", privateKeyFile)
     } else {
         privateKeyData = generatePrivateKey(privateKeyFile)
     }
 
     if (fs.existsSync(connFile)) {
-        connection = JSON.parse(fs.readFileSync(connFile, "utf-8"))
+        connection = JSON.parse(fs.readFileSync(connFile, "utf8"))
         LOGGER.info("Found existing connection info: %s", connFile)
     }
 
     if (fs.existsSync(crtFile)) {
-        certificateData = fs.readFileSync(crtFile, "utf-8")
+        certificateData = fs.readFileSync(crtFile)
         LOGGER.info("Found existing certificate: %s", crtFile)
     }
 }
 
-function establish(newConnection: Info, newCertificate: string, persistFiles: boolean) {
+function establish(newConnection: Info, newCertificate: Buffer, persistFiles: boolean) {
     connection = newConnection
     certificateData = newCertificate
 
@@ -55,14 +55,14 @@ function establish(newConnection: Info, newCertificate: string, persistFiles: bo
     return connection
 }
 
-export function certificate(): string {
+export function certificate(): Buffer {
     if (!established()) {
         throw new Error("Trying to access connection status without having a connection established. Please call connection.established() upfront to assure an available connection status")
     }
     return certificateData
 }
 
-export function privateKey(): string {
+export function privateKey(): Buffer {
     return privateKeyData
 }
 
@@ -70,13 +70,13 @@ export function established(): boolean {
     return connection != null
 }
 
-function generatePrivateKey(filePath: string): string {
+function generatePrivateKey(filePath: string): Buffer {
     LOGGER.debug("Generating new private key: %s", filePath)
     let keys = forge.pki.rsa.generateKeyPair(2048)
     const key = forge.pki.privateKeyToPem(keys.privateKey)
     fs.writeFileSync(filePath, key)
     LOGGER.info("Generated new private key: %s", filePath)
-    return key
+    return Buffer.from(key)
 }
 
 export function info(): Info {

--- a/modules/app-connector/src/server/kyma/common.ts
+++ b/modules/app-connector/src/server/kyma/common.ts
@@ -20,10 +20,8 @@ export function resolveError(statusCode: number, body: string, name: string) {
 export function createRequestOptions(connection: any, source: any) {
     LOGGER.debug("Calling " + source.method + " on " + source.uri)
     return Object.assign({
-        agentOptions: {
-            cert: connection.certificate(),
-            key: connection.privateKey()
-        },
+        cert: connection.certificate(),
+        key: connection.privateKey(),
         rejectUnauthorized: !connection.info().insecure,
         resolveWithFullResponse: true,
         json: true,


### PR DESCRIPTION
Running Kyma on gardener-azure caused problems while pairing the mock. It turned out to be related to a mess up in the encoding of the certificate data.
This PR fixes it by using a Buffer everywhere when dealing with certificate data applying proper encodings.