### PR TITLE
retrieve eventsurl on-demand only

### DIFF
--- a/modules/api-server/src/server/resources/api.yaml
+++ b/modules/api-server/src/server/resources/api.yaml
@@ -495,9 +495,9 @@ components:
           type: "string"
           description: "URL on connected Kyma cluster to manage APIs"
           example: https://gateway.mycluster.kyma.cx/event-trial/v1/metadata/services
-        eventsUrl:
+        infoUrl:
           type: "string"
-          description: "URL on connected Kyma cluster to send events"
+          description: "URL to retrieve more info about connected kyma cluster"
           example: https://gateway.mycluster.kyma.cx/event-trial/v1/events
         consoleUrl:
           type: "string"
@@ -511,10 +511,6 @@ components:
           type: "string"
           description: "URL on connected Kyma cluster to renew client certifactes"
           example: https://gateway.mycluster.kyma.cx/v1/applications/certificates/renewals
-        domain:
-          type: "string"
-          description: "Domain of the connected Kyma cluster"
-          example: prod-cluster
         application:
           type: "string"
           description: "Application name on connected Kyma cluster"

--- a/modules/api-server/src/server/routes/connector.ts
+++ b/modules/api-server/src/server/routes/connector.ts
@@ -61,7 +61,7 @@ function assureConnected() {
 async function connect(req: express.Request, res: express.Response) {
     try {
         await connection.connect(req.body.token, true, req.body.insecure)
-        LOGGER.info("Connected to %s", connection.info()!.domain)
+        LOGGER.info("Connected to %s", connection.info()!.metadataUrl)
         res.status(200).send(connection.info())
     } catch (error) {
         LOGGER.error("Failed to connect to kyma cluster: %s", error)

--- a/modules/app-connector/package-lock.json
+++ b/modules/app-connector/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@varkes/app-connector",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/modules/app-connector/src/server/compass/connector.ts
+++ b/modules/app-connector/src/server/compass/connector.ts
@@ -70,7 +70,7 @@ async function signCertificateSigningRequest(url: string, insecure: boolean, con
   return Buffer.from(encodedCert,'base64');
 }
 
-export async function eventsUrl(domain: string, application: string): Promise<string> {
+export async function eventsUrl(): Promise<string> {
   const query = gql`query($appId: ID!) {
     application (id : $appId){
       eventingConfiguration{
@@ -143,17 +143,15 @@ export async function connect(token: string, insecure: boolean = false): Promise
 
   let directorUrl = configResult.managementPlaneInfo.directorURL;
 
-  let domains = new URL(directorUrl).hostname.replace("compass-gateway-mtls.", "");
   let connectionData: connection.Info = {
     insecure: insecure,
     metadataUrl: directorUrl,
-    eventsUrl: null,
+    infoUrl: "",
     renewCertUrl: configResult.managementPlaneInfo.certificateSecuredConnectorURL,
     revocationCertUrl: configResult.managementPlaneInfo.certificateSecuredConnectorURL,
     consoleUrl: directorUrl.replace("compass-gateway-mtls", "compass").replace("/director/graphql", ""),
     applicationUrl: directorUrl.replace("compass-gateway-mtls", "compass").replace("/director/graphql", "/tenant/default/applications/details/"),
-    domain: domains,
-    application: "temporary",
+    application: "",
     type: connection.Type.Compass
   }
 

--- a/modules/app-connector/src/server/connection.ts
+++ b/modules/app-connector/src/server/connection.ts
@@ -50,7 +50,7 @@ function establish(newConnection: Info, newCertificate: Buffer, persistFiles: bo
         fs.writeFileSync(crtFile, certificateData, { encoding: "utf8", flag: 'wx' })
     }
 
-    LOGGER.info("Connected to %s", connection.domain)
+    LOGGER.info("Connected to %s", connection.metadataUrl)
 
     return connection
 }
@@ -113,22 +113,20 @@ export async function connect(token: string, persistFiles: boolean = true, insec
 }
 
 export async function eventsUrl(): Promise<string> {
-    let result = connection!.eventsUrl;
-    if (result) {
-        return result
-    }
-    return compassConnector.eventsUrl(connection!.domain, connection!.application);
+    if (connection!.type === Type.Kyma)
+        return kymaConnector.eventsUrl();
+    else
+        return compassConnector.eventsUrl();
 }
 
 export type Info = {
     insecure: boolean,
     metadataUrl: string,
-    eventsUrl: string | null,
+    infoUrl: string | null,
     renewCertUrl: string | null,
     revocationCertUrl: string | null,
     consoleUrl: string,
     applicationUrl: string,
-    domain: string,
     application: string
     type: Type
 }

--- a/modules/app-connector/src/test/expect/connection.json
+++ b/modules/app-connector/src/test/expect/connection.json
@@ -1,12 +1,11 @@
 {
     "insecure": false,
     "metadataUrl": ".*",
-    "eventsUrl": ".*",
+    "infoUrl": ".*",
     "renewCertUrl": ".*",
     "revocationCertUrl": ".*",
     "consoleUrl": ".*",
     "applicationUrl": ".*",
-    "domain": ".*",
     "application": ".*",
     "type": "Kyma"
 }

--- a/modules/cockpit/src/app/connectionOverview/connection.overview.html
+++ b/modules/cockpit/src/app/connectionOverview/connection.overview.html
@@ -37,6 +37,7 @@
         </div>
       </div>
 
+      <div *ngIf="connection.applicationUrl">
       <table class="fd-table fd-table--no-borders">
         <tbody>
           <tr>
@@ -49,7 +50,7 @@
           <tr>
             <td class="y-fd-table--col-2 fd-has-color-text-4">Cluster</td>
             <td>
-              <a href="{{connection.consoleUrl}}" target="_blank">{{connection.domain}} <span
+              <a href="{{connection.consoleUrl}}" target="_blank">{{connection.consoleUrl}} <span
                   class="sap-icon--action sap-icon--s"></span></a>
             </td>
           </tr>
@@ -62,6 +63,7 @@
           </tr>
         </tbody>
       </table>
+      </div>
     </section>
 
   </header>


### PR DESCRIPTION
**Problem**
The url to send events is retrieved once after the pairing process in the legacy mode. Connecting to compas in the legacy mode still does not mean that the url is available or will not change as the runtime assignment is not done or will change.

**Solution**
Do not store the eventsUrl after pairing but instead store the infoUrl where the eventsUrl can be retrieved on demand.