### PR TITLE
added option to force traces on kyma side

### DIFF
--- a/modules/app-connector/src/server/kyma/event.ts
+++ b/modules/app-connector/src/server/kyma/event.ts
@@ -10,12 +10,16 @@ const LOGGER: any = config.logger("app-connector")
 
 export function send(event: any): Promise<any> {
     return connection.eventsUrl().then((eventsUrl) => {
+        let headers: any = {
+            "Content-Type": "application/json"
+        }
+        if (event["event-tracing"]) {
+            headers["x-b3-sampled"] = "1"
+        }
         return request(common.createRequestOptions(connection, {
             uri: eventsUrl,
             method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            },
+            headers: headers,
             body: event
         })).then((response: any) => {
             if (response.statusCode < 300) {

--- a/modules/cockpit/src/app/sendEventView/app.send.eventview.html
+++ b/modules/cockpit/src/app/sendEventView/app.send.eventview.html
@@ -18,7 +18,16 @@
         <h3 class="fd-panel__title">Event Topics</h3>
       </div>
       <div class="fd-panel__actions">
-        <button *ngIf="event && remote" class=" fd-button--primary fd-button--l" (click)="sendEvent()">Send
+        <div *ngIf="event && remote" class="fd-form__item fd-form__item--check" style="padding: 8px" title="When enabled, the 'x-b3-sampled' header will be set to '1' for the call to Kyma, causing the istio-proxies to collect traces no matter what trace sampling rate is configured for istio.">
+          <label class="fd-form__label" for="tracing">
+            Force Trace Sampling 
+            <span class="fd-toggle fd-toggle--compact fd-form__control" style="margin: 5px">
+                <input type="checkbox" name="tracing" id="tracing" [(ngModel)]="tracing">
+                <span class="fd-toggle__switch" role="presentation"></span>
+            </span>
+          </label>
+        </div>
+        <button *ngIf="event && remote" class="fd-button--primary fd-button--l" [attr.aria-disabled]="!topicName" (click)="sendEvent()">Send
           Event</button>
       </div>
     </div>

--- a/modules/cockpit/src/app/sendEventView/send.eventview.ts
+++ b/modules/cockpit/src/app/sendEventView/send.eventview.ts
@@ -24,6 +24,7 @@ export class SendEventViewComponent implements OnInit {
     public alertMessage;
     public ariaExpanded = false;
     public ariaHidden = true;
+    public tracing = true;
     public success;
     public topicName;
     public successMessage;
@@ -35,7 +36,7 @@ export class SendEventViewComponent implements OnInit {
 
     public async ngOnInit() {
         this.event = JSON.parse(this.event);
-        this.topics = Object.keys(this.event.events.spec.asyncapi == ASYNC_API_2 ? this.event.events.spec.channels : this.event.events.spec.topics).map((key:string) =>{
+        this.topics = Object.keys(this.event.events.spec.asyncapi == ASYNC_API_2 ? this.event.events.spec.channels : this.event.events.spec.topics).map((key: string) => {
             return key.split("/").join(".");
         });
         this.filteredTopicsNames = this.topics;
@@ -52,6 +53,9 @@ export class SendEventViewComponent implements OnInit {
     }
 
     public sendEvent() {
+        if(!this.topicName){
+            return
+        }
         this.loading = true;
         let headers = new Headers({ 'Content-Type': 'application/json' });
         let httpOptions = new RequestOptions({ headers: headers });
@@ -73,7 +77,8 @@ export class SendEventViewComponent implements OnInit {
                 "event-type": eventType,
                 "event-type-version": version, //event types normally end with .v1
                 "event-time": eventTime,
-                "data": JSON.parse(editor.getValue())
+                "data": JSON.parse(editor.getValue()),
+                "event-tracing": this.tracing
             }
             this.http.post(this.baseUrl + this.info.links.events, eventData, httpOptions)
                 .subscribe(


### PR DESCRIPTION
- Added checkbox in event send dialog to add the x-b3-sampled header to all event calls
- Disabled send button when no event topic is selected