### PR TITLE
disable cloudevents by default

### DIFF
--- a/modules/cockpit/src/app/sendEventView/send.eventview.ts
+++ b/modules/cockpit/src/app/sendEventView/send.eventview.ts
@@ -26,7 +26,7 @@ export class SendEventViewComponent implements OnInit {
     public ariaExpanded = false;
     public ariaHidden = true;
     public tracing = true;
-    public cloudevent = true;
+    public cloudevent = false;
     public success;
     public topicName;
     public successMessage;


### PR DESCRIPTION
Sending cloudevents via the UI is not working sufficient yet.
The source and type attribute is not filled proper and we need to overall improve the experience by adding form fields for filling them.

For now I will disable the feature by default in the UI